### PR TITLE
possibility to define ENABLE_CALLOC_REALLOC  as compiler flags

### DIFF
--- a/src/FreeRTOSConfig.h
+++ b/src/FreeRTOSConfig.h
@@ -85,7 +85,7 @@
 
  
 #define configUSE_PREEMPTION			1
-#define configUSE_IDLE_HOOK				0 // 0 = loop() is a dedicated task | 1 = loop() is the FreeRTOS idle hook function
+#define configUSE_IDLE_HOOK				1 // 0 = loop() is a dedicated task | 1 = loop() is the FreeRTOS idle hook function TODO
 #define configUSE_TICK_HOOK				0
 #define configCPU_CLOCK_HZ				( ( unsigned long ) F_CPU  )
 #define configTICK_RATE_HZ				( ( TickType_t ) 1000 )
@@ -149,6 +149,7 @@ FreeRTOS/Source/tasks.c for limitations. */
 header file. */
 
 extern void rtosFatalError(void);
+extern void runLoopAsTask(uint16_t stack, uint16_t priority);
 #define configASSERT( x ) \
 	if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); rtosFatalError(); }
 

--- a/src/FreeRTOSConfig.h
+++ b/src/FreeRTOSConfig.h
@@ -85,7 +85,7 @@
 
  
 #define configUSE_PREEMPTION			1
-#define configUSE_IDLE_HOOK				1
+#define configUSE_IDLE_HOOK				0 // 0 = loop() is a dedicated task | 1 = loop() is the FreeRTOS idle hook function
 #define configUSE_TICK_HOOK				0
 #define configCPU_CLOCK_HZ				( ( unsigned long ) F_CPU  )
 #define configTICK_RATE_HZ				( ( TickType_t ) 1000 )

--- a/src/heap_4bis.c
+++ b/src/heap_4bis.c
@@ -435,7 +435,9 @@ uint8_t *puc;
 }
 
 // non standard contributed feature that can be enabled
+#ifndef ENABLE_CALLOC_REALLOC
 #define ENABLE_CALLOC_REALLOC 0
+#endif
 
 #if ENABLE_CALLOC_REALLOC
 

--- a/src/idle_hook.c
+++ b/src/idle_hook.c
@@ -1,6 +1,8 @@
 
 #include <FreeRTOS.h>
 #include <Arduino.h>
+//Arduino loop as task
+#include "task.h"
 
 uint8_t loopAsTask = 0;
 TaskHandle_t loopHandle;

--- a/src/idle_hook.c
+++ b/src/idle_hook.c
@@ -2,11 +2,30 @@
 #include <FreeRTOS.h>
 #include <Arduino.h>
 
+uint8_t loopAsTask = 0;
+TaskHandle_t loopHandle;
 
 // this is referring to the loop function of your arduino project
 extern void loop(void); 
 
 void  __attribute__((weak)) vApplicationIdleHook( void ) 
 {
-  loop(); //will use your projects loop function as the rtos idle loop
+    if (!loopAsTask)
+    {
+        loop(); //will use your projects loop function as the rtos idle loop
+    }
+}
+
+void loopTask(void *pvParameters)
+{
+    while(1)
+    {
+        loop();
+    }
+}
+
+void runLoopAsTask(uint16_t stack, uint16_t priority)
+{
+    loopAsTask = 1;
+    xTaskCreate(loopTask, "loop", stack, ( void * ) NULL, ( (UBaseType_t)priority | portPRIVILEGE_BIT ) , &loopHandle);
 }

--- a/src/tasks.c
+++ b/src/tasks.c
@@ -1559,7 +1559,7 @@ BaseType_t xReturn;
 	#if ( INCLUDE_xTaskGetIdleTaskHandle == 1 )
 	{
         #if ( configUSE_IDLE_HOOK == 0)
-        xTaskCreate(loopTask, "loop", 512, ( void * ) NULL, ( tskIDLE_PRIORITY | portPRIVILEGE_BIT ), NULL);
+        xTaskCreate(loopTask, "loop", 256, ( void * ) NULL, ( tskIDLE_PRIORITY | portPRIVILEGE_BIT ), NULL);
         #endif
 		/* Create the idle task, storing its handle in xIdleTaskHandle so it can
 		be returned by the xTaskGetIdleTaskHandle() function. */

--- a/src/tasks.c
+++ b/src/tasks.c
@@ -1540,17 +1540,6 @@ StackType_t *pxTopOfStack;
 #endif /* ( ( INCLUDE_xTaskResumeFromISR == 1 ) && ( INCLUDE_vTaskSuspend == 1 ) ) */
 /*-----------------------------------------------------------*/
 
-// this is referring to the loop function of your arduino project
-extern void loop(void);
-
-void loopTask(void *pvParameters)
-{
-    while(1)
-    {
-        loop();
-    }
-}
-
 void vTaskStartScheduler( void )
 {
 BaseType_t xReturn;
@@ -1558,9 +1547,6 @@ BaseType_t xReturn;
 	/* Add the idle task at the lowest priority. */
 	#if ( INCLUDE_xTaskGetIdleTaskHandle == 1 )
 	{
-        #if ( configUSE_IDLE_HOOK == 0)
-        xTaskCreate(loopTask, "loop", 256, ( void * ) NULL, ( tskIDLE_PRIORITY | portPRIVILEGE_BIT ), NULL);
-        #endif
 		/* Create the idle task, storing its handle in xIdleTaskHandle so it can
 		be returned by the xTaskGetIdleTaskHandle() function. */
 		xReturn = xTaskCreate( prvIdleTask, "IDLE", tskIDLE_STACK_SIZE, ( void * ) NULL, ( tskIDLE_PRIORITY | portPRIVILEGE_BIT ), &xIdleTaskHandle ); /*lint !e961 MISRA exception, justified as it is not a redundant explicit cast to all supported compilers. */

--- a/src/tasks.c
+++ b/src/tasks.c
@@ -1540,6 +1540,17 @@ StackType_t *pxTopOfStack;
 #endif /* ( ( INCLUDE_xTaskResumeFromISR == 1 ) && ( INCLUDE_vTaskSuspend == 1 ) ) */
 /*-----------------------------------------------------------*/
 
+// this is referring to the loop function of your arduino project
+extern void loop(void);
+
+void loopTask(void *pvParameters)
+{
+    while(1)
+    {
+        loop();
+    }
+}
+
 void vTaskStartScheduler( void )
 {
 BaseType_t xReturn;
@@ -1547,6 +1558,9 @@ BaseType_t xReturn;
 	/* Add the idle task at the lowest priority. */
 	#if ( INCLUDE_xTaskGetIdleTaskHandle == 1 )
 	{
+        #if ( configUSE_IDLE_HOOK == 0)
+        xTaskCreate(loopTask, "loop", 512, ( void * ) NULL, ( tskIDLE_PRIORITY | portPRIVILEGE_BIT ), NULL);
+        #endif
 		/* Create the idle task, storing its handle in xIdleTaskHandle so it can
 		be returned by the xTaskGetIdleTaskHandle() function. */
 		xReturn = xTaskCreate( prvIdleTask, "IDLE", tskIDLE_STACK_SIZE, ( void * ) NULL, ( tskIDLE_PRIORITY | portPRIVILEGE_BIT ), &xIdleTaskHandle ); /*lint !e961 MISRA exception, justified as it is not a redundant explicit cast to all supported compilers. */


### PR DESCRIPTION
This way you can enable `calloc` and `realloc` by passing the compiler flags through the Arduino extra flags of the _boards.txt_ file as an alternative to changing the library source.